### PR TITLE
add terrain to db

### DIFF
--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -1123,6 +1123,7 @@ MonoBehaviour:
   invisibleWall4: {fileID: 234963107}
   blurIterations: 2
   terrainIsLoaded: 0
+  firebaseManager: {fileID: 2099217467}
 --- !u!1 &1411949949
 GameObject:
   m_ObjectHideFlags: 0
@@ -1669,6 +1670,17 @@ MonoBehaviour:
   - {fileID: 1046077069658734051}
   - {fileID: 4774950037796701218}
   - {fileID: 26386546810657853}
+--- !u!114 &2099217467 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5742922775807658539, guid: 1513e401f20f24e59b62d86205856996, type: 3}
+  m_PrefabInstance: {fileID: 1809056906}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed9671797c273444d954ff70afd52dad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2116938144
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Simulation/Database/FirebaseManager.cs
+++ b/Assets/Scripts/Simulation/Database/FirebaseManager.cs
@@ -12,8 +12,8 @@ public class FirebaseManager : MonoBehaviour
     public string simulationId;
     void Start() {
         // Get the root reference location of the database.
-        dbReference = FirebaseDatabase.DefaultInstance.RootReference;
-        Debug.Log("firebase" + dbReference);
+        // dbReference = FirebaseDatabase.DefaultInstance.RootReference;
+        // Debug.Log("firebase" + dbReference);
     }
 
     void Awake()
@@ -23,9 +23,21 @@ public class FirebaseManager : MonoBehaviour
         dbReference = FirebaseDatabase.DefaultInstance.RootReference;
     }
 
+    public static void StoreMarsTerrainData(string simId, float terrainWidth, float terrainLength) 
+    {
+        DatabaseReference terrainRef = dbReference.Child("Simulations").Child(simId).Child("MarsGeospatialData");
+
+        var terrainData = new Dictionary<string, object>{
+            {"Length", terrainLength},
+            {"Width", terrainWidth}
+        };
+
+        terrainRef.SetValueAsync(terrainData);
+    }
+
     public static void StoreMaterialData(GameObject mineral, string carId, string simId)
     {
-        DatabaseReference newMineralRef = dbReference.Child("materials").Child(simId).Child(carId).Push(); 
+        DatabaseReference newMineralRef = dbReference.Child("Simulations").Child(simId).Child("Avatars").Child(carId).Push(); 
         var mineralData = new Dictionary<string, object>{
             {"id", mineral.name},
             {"position", new Dictionary<string, float>{

--- a/Assets/Scripts/Simulation/Spawning/StartupSpawner.cs
+++ b/Assets/Scripts/Simulation/Spawning/StartupSpawner.cs
@@ -52,6 +52,8 @@ public class StartupSpawner : MonoBehaviour
 
     // This is our local "root" for the entire simulation
     private Transform simulationRoot;
+    public FirebaseManager firebaseManager; // Reference to the Firebase manager
+
 
     public void SetRowCol(int row, int col){
         spawnTileRow = row;
@@ -62,6 +64,8 @@ public class StartupSpawner : MonoBehaviour
     {
         // 1. Store a reference to the SimulationPrefab’s transform
         simulationRoot = this.transform;
+        firebaseManager = FindObjectOfType<FirebaseManager>();
+
 
         ELEVATION_RANGE = (MAX_ELEVATION - MIN_ELEVATION) * heightScale;
         car.transform.localScale = new Vector3(scaleFactor, scaleFactor, scaleFactor);
@@ -85,6 +89,8 @@ public class StartupSpawner : MonoBehaviour
         StartCoroutine(DownloadDustTexture(spawnTileRow, spawnTileCol));
         StartCoroutine(SpawnCarDelay(chunkCenter));
         InitializeInvisibleWalls(TerrainWidth, TerrainLength, 120f);
+        FirebaseManager.StoreMarsTerrainData(firebaseManager.simulationId, TerrainWidth, TerrainLength);
+
     }
 
     private IEnumerator SpawnCarDelay(Vector3 chunkCenter)

--- a/Assets/Scripts/Simulation/UI/InventoryManager.cs
+++ b/Assets/Scripts/Simulation/UI/InventoryManager.cs
@@ -32,7 +32,7 @@ public class InventoryManager : MonoBehaviour
         simulationManager = FindObjectOfType<SimulationManager>();
         firebaseManager = FindObjectOfType<FirebaseManager>();
         currentCarId = simulationManager.roverIds[simulationManager.curIdx]; // Initialize with the current car ID
-        materialsRef = FirebaseManager.dbReference.Child("materials").Child(firebaseManager.simulationId).Child(currentCarId);
+        materialsRef = FirebaseManager.dbReference.Child("Simulations").Child(firebaseManager.simulationId).Child("Avatars").Child(currentCarId);
 
         // Add listeners for pagination buttons
         nextButton.onClick.AddListener(NextPage);


### PR DESCRIPTION
When startup spawner starts, it adds the terrain length and width to the database. DB structure is refactored to include terrain data within the simulation.